### PR TITLE
FEAT 각 factoryAdmin 제어권한 부여 기능 구현

### DIFF
--- a/models/factory.js
+++ b/models/factory.js
@@ -27,6 +27,7 @@ class Factory extends Sequelize.Model {
       foreignKey: 'factoryId',
       otherKey: 'userId',
     });
+    this.hasMany(models.Line, { foreignKey: 'factoryId' });
   }
 }
 

--- a/models/index.js
+++ b/models/index.js
@@ -12,12 +12,18 @@ db.sequelize = sequelize;
 db.User = User;
 db.Factory = Factory;
 db.UserFactory = UserFactory; // UserFactory 추가
+db.Line = Line;
+db.UserLinePermission = UserLinePermission;
 
 User.init(sequelize);
 Factory.init(sequelize);
 UserFactory.init(sequelize);
+Line.init(sequelize);
+UserLinePermission.init(sequelize);
 
 User.associate(db);
 Factory.associate(db);
+Line.associate(db);
+// UserLinePermission.associate(db);
 
 export default db;

--- a/models/line.js
+++ b/models/line.js
@@ -20,7 +20,7 @@ class Line extends Sequelize.Model {
         modelName: 'Line',
         tableName: 'lines',
         underscored: true,
-        timestamps: true,
+        timestamps: false,
         paranoid: true,
       }
     );
@@ -28,7 +28,10 @@ class Line extends Sequelize.Model {
 
   static associate(models) {
     this.belongsTo(models.Factory, { foreignKey: 'factoryId' });
-    // this.belongsToMany(models.User, { through: models.UserLinePermission });
+    this.belongsToMany(models.User, {
+      through: models.UserLinePermission,
+      foreignKey: 'lineId',
+    });
   }
 }
 

--- a/models/user.js
+++ b/models/user.js
@@ -50,6 +50,10 @@ class User extends Sequelize.Model {
       foreignKey: 'userId',
       otherKey: 'factoryId',
     });
+    this.belongsToMany(models.Line, {
+      through: models.UserLinePermission,
+      foreignKey: 'userId',
+    });
   }
 }
 

--- a/models/userLinePermission.js
+++ b/models/userLinePermission.js
@@ -1,34 +1,16 @@
 import { Sequelize } from 'sequelize';
+import { toDefaultValue } from 'sequelize/lib/utils';
 
 class UserLinePermission extends Sequelize.Model {
   static init(sequelize) {
     return super.init(
       {
-        userId: {
-          type: Sequelize.INTEGER,
-          references: {
-            model: 'User',
-            key: 'id',
-          },
-        },
-        lineId: {
-          type: Sequelize.INTEGER,
-          references: {
-            model: 'Line',
-            key: 'id',
-          },
-        },
-        canControl: {
-          type: Sequelize.BOOLEAN,
-          defaultValue: false,
-        },
+        canControl: Sequelize.BOOLEAN,
       },
       {
         sequelize,
         modelName: 'UserLinePermission',
-        underscored: true,
         timestamps: true,
-        paranoid: true,
       }
     );
   }

--- a/routes/factoryAdmin.js
+++ b/routes/factoryAdmin.js
@@ -22,4 +22,25 @@ router.get(
   }
 );
 
+// 공장 별 사용자 제어 권한 변경
+router.put('/user-line-control/:id', isAuthenticated, async (req, res) => {
+  try {
+    const params = {
+      id: req.params.id, // 변경할 사용자 id
+      userId: req.user.id, // 요청한 admin의 id => 어느 factory의 admin인지 확인하기 위함
+      lines: req.body.lines, // line id 배열 [ "1호기", "2호기" ]
+    };
+    const result = await userService.updateUserLineControl(params);
+    console.log('result', result);
+    if (result === true) {
+      res.status(200).json(result);
+    } else {
+      res.status(400).json(result);
+    }
+  } catch (error) {
+    logger.error('factoryAdmin.userLineControl.Error', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
 export default router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -67,7 +67,7 @@ router.get('/userinfo', async (req, res) => {
   }
   try {
     const params = {
-      userId: req.session.userId,
+      userId: req.user.id,
     };
     const result = await userService.getUserInfo(params);
     console.log(result);


### PR DESCRIPTION
/admin/user-line-control/:id
=> 각각의 공장 어드민이 각 공장의 사원들에게 제어권한 부여, 취소 가능한 기능 구현
     
 ```
id: req.params.id, // 변경할 사용자 id
userId: req.user.id, // 요청한 admin의 id => 어느 factory의 admin인지 확인하기 위함
lines: req.body.lines, // line id 배열 [ "1호기", "2호기" ]
```

admin의 id 값으로 해당 어드민 어느 공장 어드민인지 확인 후 각 공장에 소속된 사원의 제어권한 요청하면,
확인된 공장의 Line (id, name, factoryId) 조회 후 기존에 부여 받았던 제어 권한 삭제 후 어드민의 공장 소속에 맞춰서
(1공장이면 1공장 제어권한, 2공장이면 2공장 제어권한) 각 호기에 대한 권한을 부여

line으로 ""을 보내면 모든 권한 삭제됨
